### PR TITLE
Add GitHub Actions workflow for web deployment

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,0 +1,47 @@
+name: Build and Deploy Web
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: web-pages
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Export web build
+        uses: firebelley/godot-export@v6
+        with:
+          godot_executable_download_url: https://github.com/godotengine/godot-builds/releases/download/4.5-stable/Godot_v4.5-stable_linux.x86_64.zip
+          godot_export_templates_download_url: https://github.com/godotengine/godot-builds/releases/download/4.5-stable/Godot_v4.5-stable_export_templates.tpz
+          export_presets_path: export_presets.cfg
+          relative_export_path: build
+          cache: true
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: build/web
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4

--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -1,0 +1,24 @@
+[gd_resource type="ConfigFile" format=3]
+
+[resource]
+
+[preset.0]
+name="Web"
+platform="Web"
+runnable=true
+advanced_options=false
+dedicated_server=false
+custom_features=""
+export_filter="all_resources"
+include_filter=""
+exclude_filter=""
+export_path="build/web/index.html"
+script_encryption_key=""
+
+[preset.0.options]
+custom_template/debug=""
+custom_template/release=""
+variant/export_mode=0
+variant/html/export_icon=true
+variant/html/custom_html_shell=""
+variant/html/head_include=""


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that exports a web build and publishes it to GitHub Pages
- define a Web export preset so the automated export has a configured target

## Testing
- not run (deployment automation only)


------
https://chatgpt.com/codex/tasks/task_e_68de4760ca64832e8308792b29c295f2