### PR TITLE
Update Godot export action version

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Export web build
-        uses: firebelley/godot-export@v6
+        uses: firebelley/godot-export@v7
         with:
           godot_executable_download_url: https://github.com/godotengine/godot-builds/releases/download/4.5-stable/Godot_v4.5-stable_linux.x86_64.zip
           godot_export_templates_download_url: https://github.com/godotengine/godot-builds/releases/download/4.5-stable/Godot_v4.5-stable_export_templates.tpz


### PR DESCRIPTION
## Summary
- bump the GitHub Actions Godot export action to version 7 to resolve CI failures

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de4d577400832eb6db1f3f99b119a8